### PR TITLE
Fix a 'A non well formed numeric value encountered' notice with PHP 7

### DIFF
--- a/app/code/community/Owebia/Shipping2/Model/ConfigParser.php
+++ b/app/code/community/Owebia/Shipping2/Model/ConfigParser.php
@@ -30,13 +30,16 @@ class Owebia_Shipping2_Model_ConfigParser
     public static function parseSize($size)
     {
         $size = trim($size);
-        $last = strtolower($size[strlen($size)-1]);
+        $last = $size[strlen($size)-1];
+        $size = rtrim($size, $last);
+        $size = (float)$size;
+        $last = strtolower($last);
         switch ($last) {
             case 'g': $size *= 1024;
             case 'm': $size *= 1024;
             case 'k': $size *= 1024;
         }
-        return (float)$size;
+        return $size;
     }
 
     public static function formatSize($size)


### PR DESCRIPTION
A 'A non well formed numeric value encountered' notice appeared with PHP 7.1.2. It's annoying when you develop in a strict PHP environment. 

In order to fix it, I converted string $size method in a float before the calc in parseSize method.