### PR TITLE
Remove useless process variable

### DIFF
--- a/app/code/community/Owebia/Shipping2/Model/Carrier/Abstract.php
+++ b/app/code/community/Owebia/Shipping2/Model/Carrier/Abstract.php
@@ -31,7 +31,6 @@ abstract class Owebia_Shipping2_Model_Carrier_Abstract extends Mage_Shipping_Mod
 
     public function getAllowedMethods()
     {
-        $process = array();
         $config = $this->_getConfig();
         $allowedMethods = array();
         if (count($config)>0) {


### PR DESCRIPTION
Hi,

It seems this `$process` variable is never used in this method.